### PR TITLE
Added 'Overview' link to homepage accordions, fixed ToC bug

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,12 +10,14 @@ params:
       enquire_email_footer_bioinformatics: "For bioinformatics support, please contact"
       support_feedback: Support & Feedback
       privacy: Privacy Notice
+      overview: Overview
     sv:
       home_title: Snabbare forskning genom datadelning
       enquire_email_footer_dc: "För att fråga om hur man samarbetar på plattformen"
       enquire_email_footer_bioinformatics: "För support inom bioinformatik, kontakta"
       support_feedback: Support och Feedback
       privacy: Integritetspolicy
+      overview: Översikt
 
 languages:
   en:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,7 +6,8 @@
         {{- partial "header.html" . -}}
         {{- block "header" . }}{{- end }}
         <div id="content">
-            {{ if or (gt .WordCount 500) (.Params.toc) }}
+            {{ $auto_toc := and (not (isset .Params "toc")) (gt .WordCount 500) }}
+            {{ if or ($auto_toc) (.Params.toc) }}
                 <div class="container">
                     <div class="row">
                         <div class="col-md-3 order-md-last">{{- partial "toc.html" . -}}</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,6 +8,7 @@
 {{ end }}
 
 {{ define "main" }}
+  {{ $overview := (index $.Site.Params.lang_strings .Site.Language.Lang).overview }}
 
   {{ .Content }}
 
@@ -31,8 +32,9 @@
           {{ if .HasChildren }}
           <div id="{{ urlize .Identifier }}" class='collapse' data-parent="#{{ urlize .Parent }}_accordion">
             <ul class="list-group list-group-flush border-top">
+              <li class="list-group-item"><a href="{{ .URL }}"><span class="mr-2">{{ $overview }}</span>{{ .Post }}</a></li>
               {{ range .Children }}
-                <li class="list-group-item"><a href="{{ .URL }}">{{ .Pre }}<span class="{{ if .Pre }}ml-2{{ end }} mr-2">{{ .Name }}</span>{{ .Post }}</a></li>
+                <li class="list-group-item"><a href="{{ .URL }}"><span class="mr-2">{{ .Name }}</span>{{ .Post }}</a></li>
               {{ end }}
             </ul>
           </div>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -26,6 +26,10 @@ img[src$='#floatright']{
 h2,h3,h4,h5,h6 {
     margin-top: 2rem;
 }
+div > h2:first-of-type,
+aside > h5 {
+    margin-top: 0;
+}
 
 .navbar .navbar-brand {
     max-width: 60%;


### PR DESCRIPTION
* The table of contents had an issue where setting it to false didn't turn it off. Now fixed.
* Reduced the margins on headings at the top of pages.
* On the homepage, sections that have subpages now automatically have an 'Overview' link added to the top of the accordion, so that the title page can be accessed via a link.