### PR TITLE
Remove 'overview' links on homepage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,14 +14,12 @@ params:
       enquire_email_footer_bioinformatics: "For bioinformatics support, please contact"
       support_feedback: Support & Feedback
       privacy: Privacy Notice
-      overview: Overview
     sv:
       home_title: Snabbare forskning genom datadelning
       enquire_email_footer_dc: "För att fråga om hur man samarbetar på plattformen"
       enquire_email_footer_bioinformatics: "För support inom bioinformatik, kontakta"
       support_feedback: Support och Feedback
       privacy: Integritetspolicy
-      overview: Översikt
 
 languages:
   en:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -8,7 +8,6 @@
 {{ end }}
 
 {{ define "main" }}
-  {{ $overview := (index $.Site.Params.lang_strings .Site.Language.Lang).overview }}
 
   {{ .Content }}
 
@@ -32,7 +31,6 @@
           {{ if .HasChildren }}
           <div id="{{ urlize .Identifier }}" class='collapse' data-parent="#{{ urlize .Parent }}_accordion">
             <ul class="list-group list-group-flush border-top">
-              <li class="list-group-item"><a href="{{ .URL }}"><span class="mr-2">{{ $overview }}</span>{{ .Post }}</a></li>
               {{ range .Children }}
                 <li class="list-group-item"><a href="{{ .URL }}"><span class="mr-2">{{ .Name }}</span>{{ .Post }}</a></li>
               {{ end }}


### PR DESCRIPTION
Got rid of the dropdown "Overview" links on the homepage.

![image](https://user-images.githubusercontent.com/465550/82418733-a353f780-9a7d-11ea-9117-2fdb44e1fb4e.png)
