### PR TITLE
Rename sections to resources and text and literature

### DIFF
--- a/content/english/support_services/resources.md
+++ b/content/english/support_services/resources.md
@@ -1,8 +1,8 @@
 ---
-title: Tools and models for AI
+title: Resources
 menu:
     main:
-        identifier: tools_and_models_for_ai
+        identifier: resource_services
         parent: support_services
         weight: 30
         pre: <i class="fas fa-project-diagram"></i>

--- a/content/english/support_services/text_and_literature.md
+++ b/content/english/support_services/text_and_literature.md
@@ -1,8 +1,8 @@
 ---
-title: Verktyg för samarbeten
+title: Text and Literature
 menu:
     main:
-        identifier: tools_for_collaborations
+        identifier: text_and_literature
         parent: support_services
         weight: 40
         pre: <i class="fas fa-share-alt"></i>

--- a/content/svenska/support_services/resources.md
+++ b/content/svenska/support_services/resources.md
@@ -1,8 +1,8 @@
 ---
-title: Verktyg och modeller för AI
+title: Resurser
 menu:
     main:
-        identifier: tools_and_models_for_ai
+        identifier: resource_services
         parent: support_services
         weight: 30
         pre: <i class="fas fa-project-diagram"></i>

--- a/content/svenska/support_services/text_and_literature.md
+++ b/content/svenska/support_services/text_and_literature.md
@@ -1,8 +1,8 @@
 ---
-title: Tools for collaborations
+title: Texter och litteratur
 menu:
     main:
-        identifier: tools_for_collaborations
+        identifier: text_and_literature
         parent: support_services
         weight: 40
         pre: <i class="fas fa-share-alt"></i>


### PR DESCRIPTION
Changing the titles according to Johans suggestion.

The identifier for the `Resources` section is set to `resource_service` as just `resources` felt like an identifier that may easily mess things up in the future.

No content added inside the sections.

`git mv` seems to have mixed up which file went where, so the diff looks a bit special.

Kind of closes #57  