### PR TITLE
GitHub actions - don't run on forked repos

### DIFF
--- a/.github/workflows/dockerhub-dev.yml
+++ b/.github/workflows/dockerhub-dev.yml
@@ -7,14 +7,15 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'ScilifelabDataCentre/covid-portal'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: scilifelabdatacentre/covid-portal
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        dockerfile: container/Dockerfile
-        tags: "dev"
+      - uses: actions/checkout@v2
+      - name: Publish to Docker Hub
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: scilifelabdatacentre/covid-portal
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerfile: container/Dockerfile
+          tags: "dev"

--- a/.github/workflows/dockerhub-latest.yml
+++ b/.github/workflows/dockerhub-latest.yml
@@ -7,14 +7,15 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'ScilifelabDataCentre/covid-portal'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: scilifelabdatacentre/covid-portal
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        dockerfile: container/Dockerfile
-        tags: "latest"
+      - uses: actions/checkout@v2
+      - name: Publish to Docker Hub
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: scilifelabdatacentre/covid-portal
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          dockerfile: container/Dockerfile
+          tags: "latest"


### PR DESCRIPTION
I kept getting failure emails because GitHub actions could not push to Docker Hub when running on forks of the repo.

Adding this `if` check should mean that the actions only run on the main fork.