### PR TITLE
Updated links and some text for proteins and imaging data types.

### DIFF
--- a/content/english/data_types/imaging_data/data.md
+++ b/content/english/data_types/imaging_data/data.md
@@ -10,5 +10,5 @@ menu:
 
 ## Published Data
 
-Published data related to the COVID-19 outbreak:
-* [EBI Portal](https://www.covid19dataportal.org/sequences)
+Imaging data at the EMBL-EBI:
+* [BioImage Archive](https://www.ebi.ac.uk/bioimage-archive/)

--- a/content/english/data_types/protein_data/data.md
+++ b/content/english/data_types/protein_data/data.md
@@ -14,5 +14,6 @@ The [Human Protein Atlas](https://www.proteinatlas.org) provides open access to 
 
 A special page has been dedicated to [human proteins and Covid19](https://www.proteinatlas.org/humanproteome/sars-cov-2).
 
-Other published data related to the COVID-19 outbreak:
-* [EBI Portal](https://www.covid19dataportal.org/sequences)
+Other published data:
+* [Protein sequences at EBI Portal](https://www.covid19dataportal.org/proteins)
+* [Protein structures at EBI portal](https://www.covid19dataportal.org/structures)

--- a/content/svenska/data_types/imaging_data/data.md
+++ b/content/svenska/data_types/imaging_data/data.md
@@ -10,5 +10,5 @@ menu:
 
 ## Publicerad data
 
-Publicerat datamaterial rörande COVID-19 epidemin:
-* [EBI Portal](https://www.covid19dataportal.org/sequences)
+Publicerade bilddata vid EMBL-EBI:
+* [BioImage Archive](https://www.ebi.ac.uk/bioimage-archive/)

--- a/content/svenska/data_types/protein_data/data.md
+++ b/content/svenska/data_types/protein_data/data.md
@@ -10,5 +10,6 @@ menu:
 
 ## Publicerad data
 
-Publicerat datamaterial rörande COVID-19 epidemin:
-* [EBI Portal](https://www.covid19dataportal.org/sequences)
+Publicerat proteindata:
+* [Proteinsekvenser vid EBI Data Portal](https://www.covid19dataportal.org/sequences)
+* [Proteinstrukturer vid EBI Data Portal](https://www.covid19dataportal.org/structures)

--- a/content/svenska/data_types/protein_data/data.md
+++ b/content/svenska/data_types/protein_data/data.md
@@ -10,6 +10,10 @@ menu:
 
 ## Publicerad data
 
+[Human Protein Atlas](https://www.proteinatlas.org) tillhandahåller öppen data för proteinuttrycksnivåer i mänskliga organ, vävnader och celler. Denna proteinresurs är organiserad i olika delar som fokuserar på uttryck i vävnader, subcellulära proteinuttrycksnivåer, protein i hjärnan eller i blodet, och protein relaterade till patologi och metaboliska nätverk.
+
+En särskild sida dedikeras till [humana proteiner och Covid-19](https://www.proteinatlas.org/humanproteome/sars-cov-2).
+
 Publicerat proteindata:
 * [Proteinsekvenser vid EBI Data Portal](https://www.covid19dataportal.org/sequences)
 * [Proteinstrukturer vid EBI Data Portal](https://www.covid19dataportal.org/structures)


### PR DESCRIPTION
The links were all pointing at sequences at EBI.