### PR TITLE
Add screen-reader 'skip to content' link

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ params:
       enquire_email_footer_bioinformatics: "För support inom bioinformatik, kontakta"
       support_feedback: Support och Feedback
       privacy: Integritetspolicy
-      skip_to_content: Hoppa till huvudinnehåll
+      skip_to_content: Hoppa till innehållet
 
 languages:
   en:

--- a/config.yaml
+++ b/config.yaml
@@ -14,12 +14,14 @@ params:
       enquire_email_footer_bioinformatics: "For bioinformatics support, please contact"
       support_feedback: Support & Feedback
       privacy: Privacy Notice
+      skip_to_content: Skip to main content
     sv:
       home_title: Snabbare forskning genom datadelning
       enquire_email_footer_dc: "Kontakta den svenska Covid-19 dataportalen"
       enquire_email_footer_bioinformatics: "För support inom bioinformatik, kontakta"
       support_feedback: Support och Feedback
       privacy: Integritetspolicy
+      skip_to_content: Hoppa till huvudinnehåll
 
 languages:
   en:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="{{ .Site.Language.Lang }}">
     {{- partial "head.html" . -}}
     <body>
+        <a class="sr-only sr-only-focusable" href="#content">{{ (index $.Site.Params.lang_strings .Site.Language.Lang).skip_to_content }}</a>
         {{- partial "navbar.html" . -}}
         {{- partial "header.html" . -}}
         {{- block "header" . }}{{- end }}
@@ -14,7 +15,7 @@
                 </div>
             </div>
         {{ else }}
-            <div class="container mt-5 content">
+            <div class="container mt-5 content" id="content">
                 {{- block "main" . }}{{- end }}
             </div>
         {{ end }}


### PR DESCRIPTION
Hidden by default, shows if you `tab` to select it:

![image](https://user-images.githubusercontent.com/465550/83487790-fa10f680-a4ab-11ea-8078-99d991884ece.png)

Will be visible by default for browsers with assistive tech turned on. See https://getbootstrap.com/docs/4.0/getting-started/accessibility/#visually-hidden-content