### PR TITLE
Text and Literature link

### DIFF
--- a/content/english/support_services/resources.md
+++ b/content/english/support_services/resources.md
@@ -34,7 +34,8 @@ SNIC is a national research infrastructure that makes available large-scale high
 ## Data
 
 ### Text data
-See [Text and Literature](../text_and_literature).
+See [Text and Literature](
+https://github.com/ScilifelabDataCentre/covid-portal/blob/develop/content/english/support_services/text_and_literature.md).
 
 ### Clinical data and clinical trials
 


### PR DESCRIPTION
Fixed the link to Text and Literature mentioned in resources.md. It was "../text_and_literature" that displayed 404 page. Replaced with full link :)