### PR TITLE
NPC plots: x-scroll on mobile

### DIFF
--- a/content/english/data_types/health_data/npc-statistics.md
+++ b/content/english/data_types/health_data/npc-statistics.md
@@ -7,19 +7,27 @@ menu:
         weight: 10
 ---
 
-<div id="stacked-bar-chart"></div>
-
-<div id="cumulative-plot"></div>
-
-The aggregated statistics for the PCR-based tests are shown in the graphs.
-The term "failed" indicates a test that was inconclusive or invalid
-for technical reasons.
-
 The National Pandemic Centre (NPC) is a lab for
 [Covid-19 testing](https://ki.se/mtc/ctmr-and-covid-19) set up within the
 [Centre for Translational Microbiome Research (CTMR)](https://ki.se/en/research/centre-for-translational-microbiome-research-ctmr)
 at [Karolinska Institutet (KI)](https://ki.se/en) and was financed by the
 [Knut and Alice Wallenberg Foundation (KAW)](https://kaw.wallenberg.org/en).
+
+#### Daily NPC test results
+
+<div class="d-md-none alert alert-info">Scroll the plot sideways to view all data</div>
+
+<div class="plot_wrapper"><div id="stacked-bar-chart"></div></div>
+
+#### Cumulative NPC test numbers
+
+<div class="d-md-none alert alert-info">Scroll the plot sideways to view all data</div>
+
+<div class="plot_wrapper"><div id="cumulative-plot"></div></div>
+
+The aggregated statistics for the PCR-based tests are shown in the graphs.
+The term "failed" indicates a test that was inconclusive or invalid
+for technical reasons.
 
 The dataset visualized in the graphs is available
 [here](https://datagraphics.dckube.scilifelab.se/dataset/65c5d7e6b505420c98714a4b348bafbb) and is updated daily.

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -161,3 +161,8 @@ footer img {
     text-align: center;
     width: 1.25em;
 }
+
+.plot_wrapper {
+    max-width: 100%;
+    overflow-x: auto;
+}


### PR DESCRIPTION
* Put the plots in a wrapper which makes them scroll sideways instead of exceeding the page width
* Added a warning that is only visible on small screens that the user needs to scroll to see the full data.

### Before (mobile):

<img src="https://user-images.githubusercontent.com/465550/83891525-97d72080-a74d-11ea-85d2-ed54d95e11ce.png" height=400>

### After (mobile):

<img src="https://user-images.githubusercontent.com/465550/83892068-6c086a80-a74e-11ea-8089-af521a22a220.gif" height=400>

### After (desktop):

![localhost_1313_data_types_health_data_npc-statistics_](https://user-images.githubusercontent.com/465550/83891998-4da26f00-a74e-11ea-8433-2207d14517bf.png)