### PR TITLE
NPC stats - show scroll warning slightly earlier

### DIFF
--- a/content/english/data_types/health_data/npc-statistics.md
+++ b/content/english/data_types/health_data/npc-statistics.md
@@ -12,7 +12,7 @@ menu:
 Total number of SARS-CoV-2 (Covid-19) tests run daily, separated into
 positive, negative and invalid/inconclusive results.
 
-<div class="d-md-none alert alert-info">
+<div class="d-lg-none alert alert-info">
   Scroll the plot sideways to view all data.
 </div>
 
@@ -24,7 +24,7 @@ positive, negative and invalid/inconclusive results.
 
 The sum of all SARS-CoV-2 (Covid-19) virus tests run at NPC since the start.
 
-<div class="d-md-none alert alert-info">
+<div class="d-lg-none alert alert-info">
   Scroll the plot sideways to view all data.
 </div>
 

--- a/content/svenska/data_types/health_data/npc-statistics.md
+++ b/content/svenska/data_types/health_data/npc-statistics.md
@@ -13,7 +13,7 @@ Totala antalet SARS-CoV-2 (Covid-19)-virustester analyserade för
 varje dag, uppdelade på de med positivt, negativt eller
 icke-avgjort/felaktigt resultat.
 
-<div class="d-md-none alert alert-info">
+<div class="d-lg-none alert alert-info">
   Skrolla grafen horisontellt för att se all data.
 </div>
 <div class="plot_wrapper">
@@ -25,7 +25,7 @@ icke-avgjort/felaktigt resultat.
 Summan av alla SARS-CoV-2 (Covid-19)-virustester analyserade vid NPC
 sedan start.
 
-<div class="d-md-none alert alert-info">
+<div class="d-lg-none alert alert-info">
   Skrolla grafen horisontellt för att se all data.
 </div>
 <div class="plot_wrapper">


### PR DESCRIPTION
Show the warning about scrolling slightly earlier - at the `lg` breakpoint instead of the `md` breakpoint.