### PR TITLE
Adding Swedish language recent ten table

### DIFF
--- a/content/english/projects/dashboard.md
+++ b/content/english/projects/dashboard.md
@@ -23,9 +23,7 @@ This graph displays the number of publications (including both journal publicati
 
 ## Ten most recent publications
 
-This table displays the ten most recent publications in our database (including both journal publications and preprints). The date reflects the preprint upload date or the official journal publication date, whichever is the most recent. Authors are summarised in the same format as expected in 'in text' citations. Clicking on the title for a given publication will take you directly to that publication. Note though, that it will only be possible to read the full text of publication if it is open access or if you are granted access via a subscription (e.g. an institutional subscription, or private journal subscripton).
-
-Any additions to the manually curated publications database will become visible on this table within a day. This feature is currently only available on the English language version of the site.
+This table displays the ten most recent publications in our database (including both journal publications and preprints). The date reflects the preprint upload date or the official journal publication date, whichever is the most recent. Authors are summarised in the same format as expected in 'in text' citations. Clicking on the title for a given publication will take you directly to that publication. Note though, that it will only be possible to read the full text of publication if it is open access or if you are granted access via a subscription (e.g. an institutional subscription, or private journal subscripton). Any additions to the manually curated publications database will become visible on this table within a day.
 
 <div class="table-responsive">
 {{< recent_ten >}}

--- a/content/svenska/projects/dashboard.md
+++ b/content/svenska/projects/dashboard.md
@@ -21,9 +21,17 @@ Diagrammet visar antal publikationer (vilket inkluderar vetenskapliga artiklar o
 {{< publications_per_month >}}
 </div>
 
+## De senast publicerade publikationerna (tio senaste)
+
+Tabellen visar de tio senaste publikationerna (inkluderar både tidskriftsartiklar och preprints). Datumet som anges är antingen det första datumet ett preprint laddades upp på en preprintserver eller publikationsdatumet för vetenskapliga artiklar. Författarlistan anges i samma format som citeringar. Genom att klicka på en specifik publikation länkas du vidare till publikationen. Observera att det endast är möjligt att läsa fulltext versionen av publikationer som publiceras open access eller ifall du har tillgång till en prenumeration via högskola eller universitet samt via en egen tidskriftsprenumeration. Tillägg till den manuellt granskade publikationsdatabasen kommer bli synliga i denna tabell nästa dag.
+
+<div class="table-responsive">
+{{< recent_ten_swe >}}
+</div>
+
 ## Vanligast förekommande ord eller fraser i titlarna
 
-Detta ordmoln visar de vanligaste orden eller fraserna som förekommer i publikationernas titlar. Observera att vi har filtrerat bort funktionella ord (som 'the', 'a', 'this', etc.) samt 'COVID-19' och 'SARS-CoV-2' eftersom alla titlar innehöll dessa ord.
+Detta ordmoln visar de vanligaste orden eller fraserna som förekommer i publikationernas titlar. Observera att vi har filtrerat bort funktionella ord (som 'the', 'a', 'this', etc.) samt 'COVID-19' och 'SARS-CoV-2' eftersom alla titlar innehöll dessa ord. Alla ordmoln uppdateras veckovis.
 
 #### Alla publikationer
 
@@ -37,7 +45,7 @@ Vi visar endast anslagsgivare där vi identifierat minst 20 publikationer i publ
 
 ## Vanligast förkommande ord eller fraser i abstrakt
 
-Ordmolnen visar de vanligaste förekommande orden eller fraserna från abstrakten (inkl. både preprint och vetenskapliga artiklar). Observera att vi har filtrerat bort funktionella ord (som 'the', 'a', 'this', etc.) samt 'COVID-19' och 'SARS-CoV-2' eftersom alla abstrakt innehöll dessa ord.
+Ordmolnen visar de vanligaste förekommande orden eller fraserna från abstrakten (inkl. både preprint och vetenskapliga artiklar). Observera att vi har filtrerat bort funktionella ord (som 'the', 'a', 'this', etc.) samt 'COVID-19' och 'SARS-CoV-2' eftersom alla abstrakt innehöll dessa ord. Alla ordmoln uppdateras veckovis.
 
 #### Alla publikationer
 

--- a/layouts/shortcodes/recent_ten_swe.html
+++ b/layouts/shortcodes/recent_ten_swe.html
@@ -5,9 +5,9 @@
   <table id="topTenPubTable" class="table table-striped">
     <thead>
       <tr>
-        <th style="width:20%" scope="col">Published</th>
-        <th style="width:20%" scope="col">Authors</th>
-        <th style="width:60%" scope="col">Title</th>
+        <th style="width:20%" scope="col">Publikationsdatum</th>
+        <th style="width:20%" scope="col">Författare</th>
+        <th style="width:60%" scope="col">Titel</th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Added table of ten most recent publications to the Swedish language version of the publication statistics page. Added html with Swedish titles and added scope to both html versions. Removed some text from English version now that Swedish version available.