### PR TITLE
Bump klakegg/hugo, use latest alpine

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,5 +1,5 @@
-FROM klakegg/hugo:0.83.1-onbuild AS build
+FROM klakegg/hugo:0.91.2-onbuild AS build
 
-FROM nginx:1.21-alpine
+FROM nginx:alpine
 COPY Dockerfiles/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /target /usr/share/nginx/html


### PR DESCRIPTION
* Use a more recent Hugo for builds
* Use alpine instead of 1.21-alpine (currently corresponds to the exact same image)

I could not detect any issues during local testing.