### PR TITLE
Fix tag names

### DIFF
--- a/.github/workflows/dockerhub-develop.yml
+++ b/.github/workflows/dockerhub-develop.yml
@@ -26,4 +26,4 @@ jobs:
           file: Dockerfiles/Dockerfile
           context: .
           push: true
-          tags: scilifelabdatacentre/covid-portal:develop-latest
+          tags: scilifelabdatacentre/covid-portal:develop

--- a/.github/workflows/dockerhub-main.yml
+++ b/.github/workflows/dockerhub-main.yml
@@ -26,4 +26,4 @@ jobs:
           file: Dockerfiles/Dockerfile
           context: .
           push: true
-          tags: scilifelabdatacentre/covid-portal:latest-latest
+          tags: scilifelabdatacentre/covid-portal:latest


### PR DESCRIPTION
Change the tag names to the more common `latest` and `develop` instead of `latest-latest` and `develop-latest`.
The k8s deployment must be updated with the new tags.