### PR TITLE
Add alert about data updates to CRUSH dashboard

### DIFF
--- a/content/english/dashboards/crush_covid.md
+++ b/content/english/dashboards/crush_covid.md
@@ -11,6 +11,8 @@ aliases:
     - /data_types/health_data/crush_covid/
 ---
 
+<div class="alert alert-info"><b>Note regarding updates:</b> Data updates have been paused for the summer. Data updates will recommence in autumn.</div>
+
 <div class="containter"><div class="row mr-2 mt-2"><div class="col-lg-9"><p><b>CRUSH Covid</b> is a collaboration between the Region Uppsala and researchers from five different departments at Uppsala University. The purpose of the project is to map outbreaks of COVID-19 in Uppsala County and contribute to mitigation of their impact through informing the public. Information on the CRUSH Covid dashboard is updated every Thursday.</p>
 <p>CRUSH Covid is led by Mats Martinell (senior lecturer at the Department of Public Health and Caring Sciences, General Medicine and Preventive Medicine, Uppsala University) and Tove Fall (professor of Molecular Epidemiology at the Department of Medical Sciences, Molecular Epidemiology, Uppsala University). Sewage analysis is supported by SciLifeLab and Uppsala Vatten. Modelling work is supported by Vinnova.</p>
 <p>For questions and feedback, please contact Georgios Varotsis (<a href="mailto:georgios.varotsis@medsci.uu.se">georgios.varotsis@medsci.uu.se</a>).</p><p>CRUSH Covid has received ethical approval from the Swedish Ethical Review Authority (ref. no. 2020-04210, 2020-06315 and 2020-06501).</p>

--- a/content/svenska/dashboards/crush_covid.md
+++ b/content/svenska/dashboards/crush_covid.md
@@ -11,6 +11,8 @@ menu:
         parent: dashboards
 ---
 
+<div class="alert alert-info"><b>Kommentar angående uppdateringar:</b> Datauppdateringarna har pausats för sommaren och kommer att återupptas under hösten.</div>
+
 <div class="containter"><div class="row mr-2 mt-2"><div class="col-lg-9"><p><b>CRUSH Covid</b> är ett samarbete mellan Region Uppsala och forskare från fem olika institutioner vid Uppsala universitet. Syftet med projektet är att kartlägga utbrott av covid-19 i Uppsala län och att bidra till att dämpa påverkan genom information till allmänheten. Information på CRUSH Covids dashboard uppdateras varje torsdag.</p>
 <p>CRUSH Covid leds av Mats Martinell (universitetslektor vid Institutionen för folkhälso-och vårdvetenskap, Allmänmedicin och Preventivmedicin, Uppsala universitet) och Tove Fall (professor vid Institutionen för medicinska vetenskaper, Molekylär epidemiologi, Uppsala universitet). Provtagningen på avloppsvatten stöds av SciLifeLab och Uppsala Vatten. Data modelleringen har anslag från Vinnova.</p>
 <p>För frågor och feedback, kontakta Elin Clauson (<a href="mailto:elin.clauson@medsci.uu.se">elin.clauson@medsci.uu.se</a>).</p><p>CRUSH Covid har etiskt tillstånd från Etikprövningsmyndigheten (DNR 2020-04210, 2020-06315 och 2020-06501).</p>


### PR DESCRIPTION
Alert reflects that updates have paused for the summer and will recommence in autumn. They will get in touch when updates resume.