### PR TITLE
Fix the 8080 redirect error

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -1,6 +1,7 @@
 FROM klakegg/hugo:0.104.3-ubuntu-onbuild AS build
 
 FROM nginxinc/nginx-unprivileged:alpine
+RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf
 COPY --from=build /target /usr/share/nginx/html
 
 EXPOSE 8080


### PR DESCRIPTION
Fix previously used for the RDM Portal and worked correctly. Hopefully the same will work here. Need to test in dev instance first. We can test by clicking the 'see this page' hyperlink in text on the available research projects page